### PR TITLE
Use Travis to build packages and upload them to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ deploy:
   local-dir: build/upload
   acl: public_read
   on:
-    repo: tsg/beats-packer
-    branch: travis_build
+    repo: elastic/beats-packer
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+sudo: required
+services:
+  - docker
+
+language: go
+
+go:
+  - 1.5.1
+
+before_install:
+  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+script:
+  - make pull-images
+  # uncomment to build fresh images
+  # - make images
+  # - make push-images
+  - make deps
+  - make
+
+deploy:
+  provider: s3
+  access_key_id: AKIAIAXUU3N2C6EHT5GQ
+  secret_access_key:
+    secure: VG6DjUxIf4A1Im2XEXNpzDYxCtQxFCdWs7loKmrXl3r6W/EGiBV0CaZ8f2qqh6sV/jRYegc3J8Qq0R6T4aVDoGznArxmLYOXa1stTuO5l5K0y79CYCypkv7XlYi0cUG9iHmTRi8X+Im4P1FZl8n8q1s8YhHguLIRvhvCGjHGYm/OqdM6RVAEMwjDNTT2SdAaILnmJWdjz6TVjHU9dwuses+0gQww2kYSyWm6c86TiDjwTLcLJWhh2QJXbUcaNeu646Y/imcjdQ0UZuxmz63cO7cdeOs2jejwuFGq0ABfZPtUF7Rm1k9e/HxCzGc5m5XYutnHm8+1gh8UMBojNR/kQkPcO8YpERIGy85ndEnmWxSKXWLF6aH23EtWVDGQrWue92eXrCwkrHqNrJFoB87f7xL/sSgf/u08nC6DCZhQE22RJrKaw9cw9lUqg6ExtVmAM5TKrt1KuVD2ehI+3Ml8GN6HCIZxSmLfze6nuYwaXTKC4gCYL+QQYhbPOvpyMH6Mumh4m7Z2EwXW/LGje/dMWYO/YFQ+TjUYnfElAMvAgKmMzmUP2aZcKHR6o1urftW16iYys8GRpbr3lG+Gnvzpl8qMA8Px8c8xXPgoRxJJzRnITBIJndx2LknpNN8VD4nbGPqXFirFG1kwVd87osa0Ogg2kxlwkxJqXyuZWjgIuGA=
+  bucket: beats-nightlies
+  local-dir: build/upload
+  acl: public_read
+  on:
+    repo: tsg/beats-packer
+    branch: travis_build

--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@ Tools, scripts and docker images for cross-compiling and packaging the Elastic
 
 ## Prepare
 
-You need Go and docker installed. Prepare the rest with:
+You need Go and docker installed. This project uses several docker files, you
+can either build them with:
+
+     make images
+
+Or pull them from the Docker registry with:
+
+     make pull-images
+
+Prepare the rest with:
 
      make deps
 


### PR DESCRIPTION
To make this more convenient for travis, the image building is
no longer a Makefile dependency. Instead, the following targets
are added:
- make images - build images from docker file
- make push-images - push images to the docker hub
- make pull-images - pull images from the docker hub

The push requires the credentials for the tudorg account, but Travis
has them, so you can (ab)use it to rebuild the images if we need to
change something in the Dockerfiles.
