### PR TITLE
Set skip_cleanup to true

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,11 @@ deploy:
   on:
     repo: elastic/beats-packer
     branch: master
+  skip_cleanup: true
 
 notifications:
   hipchat:
     rooms:
       secure: nTzgxmZ2tp2tdAbcpNVGXZ3alUfxqvPQ2MTGu0OMM0U+GcgGpqFk5tlvo3Yb636V2Rhy20absE9/I7tTB6HWHSw2VYtm7IHVWN09tt/2owggqgrdOzU7nlXuuP1m4opiVoeWCtPkcQoT65eCElFYE8djX/h4TgLSdHkcA10/2ayeUBYZxajrGMIAXPXroaqg/KIJtUSvR6lL2p/ttkBDTUP+/ssxF2/4jKDG7fvinP6DT7jfaFsnQ1uNfBMsNc3xDMVfK1MxBraC2300MEX/y2P+3jqhwqjcWDtvskm9ONmq1IF+oav5Vjqo/TWvCYuEDSdVAKzzHcebVgerT7NH0ui+9IW2O5c9q2v+5QS/K4p/0h80RtB+5EoGQX7ETnm2m+7MLoxn8ALESTMoFOPWcLZGEmooGHbJLq4wR7l8NWusnvim7PQGjPIqaphf4Wrrp+H7pbaYuLFQ3sKbp1j+56Y6+NCQSYBp5RbuJLbU6iT5g6eTp4hhsN84cHlEgogXA6PwGWIwIs1ikCqoCoD0SODkWtbF4/6V5j+KPCOSZWsaB0+fTm56Md8Nk471h5vVEjXyx7K3TZJsFHPTkp1v3aaM7Vh42fLZLEUQy1AkRPjZGb8J2BMeoLup2fXENWMDV408IPcOwmuZCtN3xQdoLW3wTOJwajd9Om5TlYxsjGs=
+  email:
+    - tudor@elastic.co

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: packetbeat/deb packetbeat/rpm packetbeat/darwin packetbeat/win packetbeat/b
 	build/upload/build_id.txt
 
 .PHONY: packetbeat topbeat filebeat
-packetbeat topbeat filebeat: build
+packetbeat topbeat filebeat: build/upload
 	# cross compile on ubuntu
 	cd build && xgo -image=tudorg/beats-builder \
 		-before-build=../xgo-scripts/$@_before_build.sh \
@@ -60,8 +60,8 @@ go-daemon-image:
 build/god-linux-386 build/god-linux-amd64:
 	docker run -v $(shell pwd)/build:/build tudorg/go-daemon
 
-build:
-	mkdir -p build
+build/upload:
+	mkdir -p build/upload
 
 build/upload/build_id.txt:
 	echo $(BUILDID) > build/upload/build_id.txt

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ BUILDID?=$(DATE)
 .PHONY: all
 all: packetbeat/deb packetbeat/rpm packetbeat/darwin packetbeat/win packetbeat/bin \
 	topbeat/deb topbeat/rpm topbeat/darwin topbeat/win topbeat/bin \
-	filebeat/deb filebeat/rpm filebeat/darwin filebeat/win filebeat/bin
-
+	filebeat/deb filebeat/rpm filebeat/darwin filebeat/win filebeat/bin \
+	build/upload/build_id.txt
 
 .PHONY: packetbeat topbeat filebeat
 packetbeat topbeat filebeat: build
@@ -63,9 +63,11 @@ build/god-linux-386 build/god-linux-amd64:
 build:
 	mkdir -p build
 
+build/upload/build_id.txt:
+	echo $(BUILDID) > build/upload/build_id.txt
+
 .PHONY: s3-nightlies-upload
 s3-nightlies-upload: all
-	echo $(BUILDID) > build/upload/build_id.txt
 	aws s3 cp --recursive --acl public-read build/upload s3://beats-nightlies
 
 .PHONY: release-upload


### PR DESCRIPTION
This should help with avoiding error messages from git stash. Also,
I want emails when things break and explicitly create the build_id.txt file
when building all.
