### PR TITLE
Publish DEB/RPM to APT/YUM on S3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,18 @@ build/upload/build_id.txt:
 s3-nightlies-upload: all
 	aws s3 cp --recursive --acl public-read build/upload s3://beats-nightlies
 
+# Build the image required for package-upload.
+.PHONY: deb-rpm-s3
+deb-rpm-s3:
+	docker/deb-rpm-s3/build.sh
+
+# Run after building to sign packages and publish to APT and YUM repos.
+.PHONY: package-upload
+package-upload:
+	# You must export AWS_ACCESS_KEY=<AWS access> and export AWS_SECRET_KEY=<secret>
+	# before running this make target.
+	docker/deb-rpm-s3/deb-rpm-s3.sh
+
 .PHONY: release-upload
 release-upload:
 	aws s3 cp --recursive --acl public-read build/upload s3://download.elasticsearch.org/beats/

--- a/docker/deb-rpm-s3/.gitignore
+++ b/docker/deb-rpm-s3/.gitignore
@@ -1,0 +1,1 @@
+elasticsearch.asc

--- a/docker/deb-rpm-s3/Dockerfile
+++ b/docker/deb-rpm-s3/Dockerfile
@@ -6,8 +6,14 @@ FROM debian:jessie
 RUN apt-get update
 RUN apt-get install -y git \
     rubygems ruby-dev patch gcc make zlib1g-dev rpm curl dpkg-sig \
-    yum python-boto python-deltarpm \
+    yum python-deltarpm \
     expect
+
+# Install python-boto from source to get latest version.
+RUN git clone git://github.com/boto/boto.git && \
+    cd boto && \
+    git checkout 2.38.0 && \
+    python setup.py install
 
 # Install deb-s3
 RUN gem install deb-s3
@@ -16,15 +22,11 @@ RUN gem install deb-s3
 # WARNING: Pulling from master, may not be repeatable.
 RUN cd /usr/local && \
     git clone https://github.com/crohr/rpm-s3 --recursive && \
-    # Use HTTP because the S3 HTTPS are not trusted since python-2.7.9.
-    echo '[Boto]\nis_secure = False' > /etc/boto.cfg
+    echo '[s3]\ncalling_format = boto.s3.connection.OrdinaryCallingFormat' > /etc/boto.cfg
+    # Use HTTP for debugging traffic to S3.
+    #echo '[Boto]\nis_secure = False' >> /etc/boto.cfg
 ENV PATH /usr/local/rpm-s3/bin:$PATH
 ADD rpmmacros /root/.rpmmacros
-
-# Install password protected elasticsearch GPG signing key.
-ADD elasticsearch.asc .
-RUN gpg --import --allow-secret-key-import elasticsearch.asc && \
-    rm elasticsearch.asc
 
 # Add the scripts that are executed by within the container.
 ADD *.expect /

--- a/docker/deb-rpm-s3/Dockerfile
+++ b/docker/deb-rpm-s3/Dockerfile
@@ -1,0 +1,36 @@
+# Dockerfile for building an image that contains all of the necessary
+# dependencies for signing deb/rpm packages and publishing APT and YUM
+# repositories to Amazon S3.
+FROM debian:jessie
+
+RUN apt-get update
+RUN apt-get install -y git \
+    rubygems ruby-dev patch gcc make zlib1g-dev rpm curl dpkg-sig \
+    yum python-boto python-deltarpm \
+    expect
+
+# Install deb-s3
+RUN gem install deb-s3
+
+# Install rpm-s3
+# WARNING: Pulling from master, may not be repeatable.
+RUN cd /usr/local && \
+    git clone https://github.com/crohr/rpm-s3 --recursive && \
+    # Use HTTP because the S3 HTTPS are not trusted since python-2.7.9.
+    echo '[Boto]\nis_secure = False' > /etc/boto.cfg
+ENV PATH /usr/local/rpm-s3/bin:$PATH
+ADD rpmmacros /root/.rpmmacros
+
+# Install password protected elasticsearch GPG signing key.
+ADD elasticsearch.asc .
+RUN gpg --import --allow-secret-key-import elasticsearch.asc && \
+    rm elasticsearch.asc
+
+# Add the scripts that are executed by within the container.
+ADD *.expect /
+ADD publish-package-repositories.sh /
+
+# Execute the publish-package-repositories.sh when the container
+# is run.
+ENTRYPOINT ["/publish-package-repositories.sh"]
+CMD ["--help"]

--- a/docker/deb-rpm-s3/build.sh
+++ b/docker/deb-rpm-s3/build.sh
@@ -7,17 +7,4 @@ set -e
 
 cd "$(dirname "$0")"
 
-if [ ! -e "elasticsearch.asc" ]; then
-    cat << EOF
-You must place a copy of the Elasticsearch GPG signing key (named
-elasticsearch.asc) into
-  
-  $PWD
-
-prior to building this docker image.
-
-EOF
-    exit 1
-fi
-
 docker build -t deb-rpm-s3 .

--- a/docker/deb-rpm-s3/build.sh
+++ b/docker/deb-rpm-s3/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+#
+# Build script for the deb-rpm-s3 docker container.
+#
+
+cd "$(dirname "$0")"
+
+if [ ! -e "elasticsearch.asc" ]; then
+    cat << EOF
+You must place a copy of the Elasticsearch GPG signing key (named
+elasticsearch.asc) into
+  
+  $PWD
+
+prior to building this docker image.
+
+EOF
+    exit 1
+fi
+
+docker build -t deb-rpm-s3 .

--- a/docker/deb-rpm-s3/deb-rpm-s3.sh
+++ b/docker/deb-rpm-s3/deb-rpm-s3.sh
@@ -10,15 +10,34 @@
 
 cd "$(dirname "$0")"
 
+if [ ! -e "elasticsearch.asc" ]; then
+    cat << EOF
+You must place a copy of the Elasticsearch GPG signing key (named
+elasticsearch.asc) into
+  
+  $PWD
+
+prior to building this docker image.
+
+EOF
+    exit 1
+fi
+
+bucket="packages.elasticsearch.org"
+prefix="beats"
+dir="/beats-packer/build/upload"
+gpg_key="/beats-packer/docker/deb-rpm-s3/elasticsearch.asc"
+
 docker run -it --rm \
   --env="PASS=$PASS" \
   --volume `pwd`/../..:/beats-packer \
   deb-rpm-s3 \
-  --bucket=packages.elasticsearch.org \
-  --prefix=beats \
-  --directory=/beats-packer/build/upload \
+  --bucket=$bucket \
+  --prefix=$prefix \
+  --directory="$dir" \
   --aws-access-key="$AWS_ACCESS_KEY" \
   --aws-secret-key="$AWS_SECRET_KEY" \
+  --gpg-key="$gpg_key" \
   --verbose \
   "$@"
 

--- a/docker/deb-rpm-s3/deb-rpm-s3.sh
+++ b/docker/deb-rpm-s3/deb-rpm-s3.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#
+# Wrapper script for starting the docker container.
+#
+# You must set AWS_ACCESS_KEY and AWS_SECRET_KEY in your environment prior to
+# running. You can optionally pass the GPG key's passphrase as the environment
+# variable PASS.
+#
+
+cd "$(dirname "$0")"
+
+docker run -it --rm \
+  --env="PASS=$PASS" \
+  --volume `pwd`/../..:/beats-packer \
+  deb-rpm-s3 \
+  --bucket=packages.elasticsearch.org \
+  --prefix=beats \
+  --directory=/beats-packer/build/upload \
+  --aws-access-key="$AWS_ACCESS_KEY" \
+  --aws-secret-key="$AWS_SECRET_KEY" \
+  --verbose \
+  "$@"
+

--- a/docker/deb-rpm-s3/deb-s3.expect
+++ b/docker/deb-rpm-s3/deb-s3.expect
@@ -1,0 +1,18 @@
+#!/usr/bin/expect -f
+
+# Expect wrapper for deb-s3 that provides the GPG signing password
+# when prompted.
+
+spawn deb-s3 upload \
+        --sign \
+        --preserve_versions \
+        --bucket "$env(BUCKET)" \
+        --prefix "$env(PREFIX)/apt" \
+        --arch $env(arch) \
+        {*}$argv
+expect {
+  "Enter passphrase: " {
+    send -- "$env(PASS)\r"
+    exp_continue
+  }
+}

--- a/docker/deb-rpm-s3/debsign.expect
+++ b/docker/deb-rpm-s3/debsign.expect
@@ -1,0 +1,20 @@
+#!/usr/bin/expect -f
+
+# Expect wrapper for 'dpkg-sig --sign' that provides the GPG signing password
+# when prompted.
+#
+# Set password in PASS environment variable prior to running
+# this expect script.
+#
+# Example usage:
+#  expect debsign.expect example.deb
+#
+#  expect debsign.expect example.deb other.deb
+
+spawn dpkg-sig --sign builder {*}$argv
+expect {
+  "Enter passphrase: " {
+    send -- "$env(PASS)\r"
+    exp_continue
+  }
+}

--- a/docker/deb-rpm-s3/publish-package-repositories.sh
+++ b/docker/deb-rpm-s3/publish-package-repositories.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+set -e
+
+# Script directory:
+SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+usage() {
+cat << EOF
+  Usage: $(basename $0) [-vh] [-d=directory] [-b=bucket] [-p=prefix]
+    [--access-key-id=aws id] [--secret-key-id=aws secret]
+
+  Description: Sign packages and publish them to APT and YUM repositories
+    hosted from an S3 bucket. When publishing, the repository metadata is
+    also signed to prevent tampering.
+
+    You will be prompted once for the GPG signing key's password. If the
+    PASS environment variable is set then that value will be used and you
+    will not be prompted.
+
+  Options:
+    --aws-access-key=AWS_ACCESS_KEY  Required. AWS access key. Alternatively,
+                                     AWS_ACCESS_KEY may be set as an environment
+                                     variable.
+
+    --aws-secret-key=AWS_SECRET_KEY  Required. AWS secret key. Alternatively,
+                                     AWS_SECRET_KEY may be set as an environment
+                                     variable.
+
+    -b=BUCKET | --bucket=BUCKET      Required. The S3 bucket in which to publish.
+
+    -p=PREFIX | --prefix=PREFIX      Required. Path to prefix to all published
+                                     repositories.
+
+    -d=DIR | --directory=DIR         Required. Directory to recursively search
+                                     for .rpm and .deb files.
+
+    -v | --verbose                   Optional. Enable verbose logging to stderr.
+    
+    -h | --help                      Optional. Print this usage information.
+EOF
+}
+
+# Write a debug message to stderr.
+debug()
+{
+  if [ "$VERBOSE" == "true" ]; then
+    echo "DEBUG: $1" >&2
+  fi
+}
+
+# Write and error message to stderr.
+err()
+{
+  echo "ERROR: $1" >&2
+}
+
+# Parse command line arguments.
+parseArgs() {
+  for i in "$@"
+  do
+  case $i in
+    --aws-access-key=*)
+      AWS_ACCESS_KEY="${i#*=}"
+      shift
+      ;;
+    --aws-secret-key=*)
+      AWS_SECRET_KEY="${i#*=}"
+      shift
+      ;;
+    -b=*|--bucket=*)
+      BUCKET="${i#*=}"
+      shift
+      ;;
+    -d=*|--directory=*)
+      DIRECTORY="${i#*=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 1
+      ;;
+    -p=*|--prefix=*)
+      PREFIX="${i#*=}"
+      shift
+      ;;
+    -v|--verbose)
+      VERBOSE=true
+      shift
+      ;;
+    *)
+      echo "Invalid argument: $i"
+      usage
+      exit 1
+      ;;
+  esac
+  done
+
+  if [ -z "$BUCKET" ]; then
+    err "-b=BUCKET or --bucket=BUCKET is required."
+    exit 1
+  fi
+
+  if [ -z "$DIRECTORY" ]; then
+    err "-d=DIRECTORY or --directory=DIRECTORY is required."
+    exit 1
+  fi
+  
+  if [ ! -e "$DIRECTORY" ]; then
+    err "Directory $DIRECTORY does not exists."
+    exit 1
+  fi
+
+  if [ -z "$PREFIX" ]; then
+    err "-p=PREFIX or --prefix=PREFIX is required."
+    exit 1
+  fi
+
+  if [ -z "$AWS_ACCESS_KEY" ]; then
+    err "--access-key-id=AWS_ACCESS_KEY is required."
+    exit 1
+  fi
+
+  if [ -z "$AWS_SECRET_KEY" ]; then
+    err "--secret-access-key-id=AWS_SECRET_KEY is required."
+    exit 1
+  fi
+
+  export BUCKET
+  export PREFIX
+  export AWS_ACCESS_KEY
+  export AWS_SECRET_KEY
+}
+
+getPassword() {
+  if [ -z "$PASS" ]; then
+    echo -n "Enter GPG pass phrase: "
+    read -s PASS
+  fi
+
+  export PASS
+}
+
+signDebianPackages() {
+  debug "Entering signDebianPackages"
+  find $DIRECTORY -name '*.deb' | xargs expect $SDIR/debsign.expect
+  debug "Exiting signDebianPackages"
+}
+
+signRpmPackages() {
+  debug "Entering signRpmPackages"
+  find $DIRECTORY -name '*.rpm' | xargs expect $SDIR/rpmsign.expect
+  debug "Exiting signRpmPackages"
+}
+
+publishToAptRepo() {
+  debug "Entering publishToAptRepo"
+
+  # Verify the repository and credentials before continuing.
+  deb-s3 verify --bucket "$BUCKET" --prefix "${PREFIX}/apt"
+
+  for arch in i386 amd64
+  do
+    debug "Publishing $arch .deb packages..."
+    export arch
+
+    for deb in $(find "$DIRECTORY" -name "*${arch}.deb")
+    do
+      expect $SDIR/deb-s3.expect "$deb"
+    done
+  done
+}
+
+publishToYumRepo() {
+  debug "Entering publishToYumRepo"
+
+  for arch in i686 x86_64
+  do
+    debug "Publishing $arch .rpm packages..."
+    export arch
+
+    for rpm in $(find "$DIRECTORY" -name "*${arch}.rpm")
+    do
+      expect $SDIR/rpm-s3.expect "$rpm"
+    done
+  done
+}
+
+main() {
+  parseArgs $*
+  getPassword
+  signDebianPackages
+  signRpmPackages
+  publishToAptRepo
+  publishToYumRepo
+  debug "Success"
+}
+
+main $*

--- a/docker/deb-rpm-s3/rpm-s3.expect
+++ b/docker/deb-rpm-s3/rpm-s3.expect
@@ -4,8 +4,9 @@
 # when prompted.
 
 spawn rpm-s3 \
+        -vv \
+        --sign \
         --region=external-1 \
-        --verbose \
         --keep=500 \
         --visibility=public-read \
         --bucket=$env(BUCKET) \

--- a/docker/deb-rpm-s3/rpm-s3.expect
+++ b/docker/deb-rpm-s3/rpm-s3.expect
@@ -1,0 +1,19 @@
+#!/usr/bin/expect -f
+
+# Expect wrapper for rpm-s3 that provides the GPG signing password
+# when prompted.
+
+spawn rpm-s3 \
+        --region=external-1 \
+        --verbose \
+        --keep=500 \
+        --visibility=public-read \
+        --bucket=$env(BUCKET) \
+        --repopath=$env(PREFIX)/yum/el/$env(arch) \
+        {*}$argv
+expect {
+  "Enter passphrase: " {
+    send -- "$env(PASS)\r"
+    exp_continue
+  }
+}

--- a/docker/deb-rpm-s3/rpmmacros
+++ b/docker/deb-rpm-s3/rpmmacros
@@ -1,0 +1,2 @@
+%_signature gpg
+%_gpg_name Elasticsearch (Elasticsearch Signing Key) <dev_ops@elasticsearch.org>

--- a/docker/deb-rpm-s3/rpmsign.expect
+++ b/docker/deb-rpm-s3/rpmsign.expect
@@ -1,0 +1,20 @@
+#!/usr/bin/expect -f
+
+# Expect wrapper for 'rpm --resign' that provides the GPG signing password
+# when prompted.
+#
+# Set password in PASS environment variable prior to running
+# this expect script.
+#
+# Example usage:
+#  expect rpmsign.expect example.rpm
+#
+#  expect rpmsign.expect example.rpm other.rpm
+
+spawn rpm --resign \
+  --define "_signature gpg" \
+  --define "_gpg_name Elasticsearch (Elasticsearch Signing Key) <dev_ops@elasticsearch.org>" \
+  {*}$argv
+expect -exact "Enter pass phrase: "
+send -- "$env(PASS)\r"
+expect eof


### PR DESCRIPTION
Adding the ability to sign and publish packages to APT and YUM repositories hosted on Amazon S3.
