### PR TITLE
Added quotes to service-paths

### DIFF
--- a/platforms/windows/install-service.ps1.j2
+++ b/platforms/windows/install-service.ps1.j2
@@ -11,4 +11,4 @@ $workdir = Split-Path $MyInvocation.MyCommand.Path
 # create new service
 New-Service -name {{.beat_name}} `
   -displayName {{.beat_name}} `
-  -binaryPathName "$workdir\\{{.beat_name}}.exe -c $workdir\\{{.beat_name}}.yml"
+  -binaryPathName "`"$workdir\\{{.beat_name}}.exe`" -c `"$workdir\\{{.beat_name}}.yml`""


### PR DESCRIPTION
Added quotes to binaryPathName. Otherwise windows wouldn't start the service if there were any spaces in it.
