### PR TITLE
return non zero exit code on config check error

### DIFF
--- a/platforms/centos/init.j2
+++ b/platforms/centos/init.j2
@@ -49,7 +49,7 @@ start() {
 	test
 	if [ $? -ne 0 ]; then
 		echo
-		return 1
+		exit 1
 	fi
     daemon $daemonopts $wrapper $wrapperopts -- $agent $args
     RETVAL=$?


### PR DESCRIPTION
Centos init script `start` does not fail on config error.
