### PR TITLE
Added systemd unit files for debian and centos platforms

### DIFF
--- a/platforms/centos/build.sh
+++ b/platforms/centos/build.sh
@@ -7,6 +7,7 @@ runid=centos-$BEAT-$RELEASE-$ARCH
 cat beats/$BEAT.yml archs/$ARCH.yml releases/$RELEASE.yml > build/settings-$runid.yml
 gotpl platforms/centos/run.sh.j2 < build/settings-$runid.yml > build/run-$runid.sh
 gotpl platforms/centos/init.j2 < build/settings-$runid.yml > build/$runid.init
+gotpl platforms/centos/systemd.j2 < build/settings-$runid.yml > build/$runid.service
 chmod +x build/run-$runid.sh
 
 docker run -v `pwd`/build:/build -e BUILDID=$BUILDID -e RUNID=$runid --name build-image tudorg/fpm /build/run-$runid.sh

--- a/platforms/centos/run.sh.j2
+++ b/platforms/centos/run.sh.j2
@@ -7,6 +7,9 @@ cd /build
 # the init scripts needs to have the right name
 cp ${RUNID}.init /tmp/{{.beat_name}}.init
 
+# create script to reload systemd config
+echo "#!/bin/bash\nsystemctl daemon-reload 2> /dev/null || true" > /tmp/systemd-daemon-reload.sh
+
 # create rpm
 fpm --force -s dir -t rpm \
         -n {{.beat_name}} -v {{.rpm_version}} \
@@ -16,11 +19,14 @@ fpm --force -s dir -t rpm \
         --description "{{.beat_description}}" \
         --url {{.beat_url}} \
         --rpm-init /tmp/{{.beat_name}}.init \
+        --after-install /tmp/systemd-daemon-reload.sh \
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml \
         {{.beat_name}}-linux-{{.arch}}=/usr/bin/{{.beat_name}} \
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml \
         {{.beat_name}}.template.json=/etc/{{.beat_name}}/{{.beat_name}}.template.json \
-		god-linux-{{.arch}}=/usr/bin/{{.beat_name}}-god
+        ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
+        god-linux-{{.arch}}=/usr/bin/{{.beat_name}}-god
+
 
 # rename so that the filename respects semver rules
 mkdir -p upload/{{.beat_name}}

--- a/platforms/centos/systemd.j2
+++ b/platforms/centos/systemd.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description={{.beat_name}}
+Documentation=https://www.elastic.co/guide/en/beats/{{.beat_name}}/current/index.html
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/{{.beat_name}} -c /etc/{{.beat_name}}/{{.beat_name}}.yml
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/platforms/debian/build.sh
+++ b/platforms/debian/build.sh
@@ -7,6 +7,7 @@ runid=debian-$BEAT-$RELEASE-$ARCH
 cat beats/$BEAT.yml archs/$ARCH.yml releases/$RELEASE.yml > build/settings-$runid.yml
 gotpl platforms/debian/run.sh.j2 < build/settings-$runid.yml > build/run-$runid.sh
 gotpl platforms/debian/init.j2 < build/settings-$runid.yml > build/$runid.init
+gotpl platforms/centos/systemd.j2 < build/settings-$runid.yml > build/$runid.service
 chmod +x build/run-$runid.sh
 
 docker run -v `pwd`/build:/build -e BUILDID=$BUILDID -e RUNID=$runid --name build-image tudorg/fpm /build/run-$runid.sh

--- a/platforms/debian/run.sh.j2
+++ b/platforms/debian/run.sh.j2
@@ -7,6 +7,9 @@ cd /build
 # the init scripts needs to have the right name
 cp ${RUNID}.init /tmp/{{.beat_name}}.init
 
+# create script to reload systemd config
+echo "#!/bin/bash\nsystemctl daemon-reload 2> /dev/null || true" > /tmp/systemd-daemon-reload.sh
+
 # create deb
 fpm --force -s dir -t deb \
         -n {{.beat_name}} -v {{.deb_version}} \
@@ -16,10 +19,12 @@ fpm --force -s dir -t deb \
         --description "{{.beat_description}}" \
         --url {{.beat_url}} \
         --deb-init /tmp/{{.beat_name}}.init \
+        --after-install /tmp/systemd-daemon-reload.sh \
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml \
         {{.beat_name}}-linux-{{.arch}}=/usr/bin/{{.beat_name}} \
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml \
         {{.beat_name}}.template.json=/etc/{{.beat_name}}/{{.beat_name}}.template.json \
+        ${RUNID}.service=/lib/systemd/system/{{.beat_name}}.service \
 		god-linux-{{.arch}}=/usr/bin/{{.beat_name}}-god
 
 # move and rename so that the filename respects semver rules

--- a/platforms/debian/systemd.j2
+++ b/platforms/debian/systemd.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description={{.beat_name}}
+Documentation=https://www.elastic.co/guide/en/beats/{{.beat_name}}/current/index.html
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/{{.beat_name}} -c /etc/{{.beat_name}}/{{.beat_name}}.yml
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/releases/master.yml
+++ b/releases/master.yml
@@ -1,3 +1,3 @@
-version: "nightly.${BUILDID}"
-rpm_version: "nightly${BUILDID}"
-deb_version: "nightly${BUILDID}"
+version: "1.1.0-nightly${BUILDID}"
+rpm_version: "1.1.0~nightly${BUILDID}"
+deb_version: "1.1.0~nightly${BUILDID}"


### PR DESCRIPTION
- Tested with Centos7 and Ubuntu 1504
- Does the needed systemctl daemon-reload from a post script
- Copies the unit files in /lib/systemd/system even if systemd
  is not installed. Then the init script is automatically used.

Also fixes bug #40 by putting back the version numbers.
