### PR TITLE
Bumped nightlies version to 1.2

### DIFF
--- a/releases/master.yml
+++ b/releases/master.yml
@@ -1,3 +1,3 @@
-version: "1.1.0-nightly${BUILDID}"
-rpm_version: "1.1.0~nightly${BUILDID}"
-deb_version: "1.1.0~nightly${BUILDID}"
+version: "1.2.0-nightly${BUILDID}"
+rpm_version: "1.2.0~nightly${BUILDID}"
+deb_version: "1.2.0~nightly${BUILDID}"


### PR DESCRIPTION
Because master is likely to become 1.2, we're using this in the nightlies now.
