### PR TITLE
Switch to Jenkins for artifact publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 language: go
 
 go:
-  - 1.5.1
+  - 1.5.3
 
 script:
   #- make pull-images
@@ -16,27 +16,3 @@ script:
   - make deps
   - make
 
-# Workaround for Travis bug. Should be removed after this ticket is closed:
-# https://github.com/travis-ci/travis-ci/issues/5145
-before_deploy:
-  - gem install mime-types -v 2.6.2
-
-deploy:
-  provider: s3
-  access_key_id: AKIAJN76ZXKCEHHRGBGA
-  secret_access_key:
-    secure: Q1UeAGpJSMNvHHHOyGCipV5cHGQPOtprQsc12TJg6GGbvCL8aFUtR8B6Kw3iZC/EvuklaEOcoY0w+nV60J9yHt68kT6y+RUlNaj8ehYvwsVDqH8aSYXecG27EItM93ZtpmFHJ4wCtm7UCM19sLnOBiNZ5YnBbEZx7+2DNL2UZ1tUUspLu+8ZKHk8LI3C5tmXqQQ6gRcFeGewkIbSlBQ8+zXX3wpCpme3W1AQHl4JQwmam4q3Jty+8Oys01HZf8uOFrH4bVevaS0/ThcjVGtE8H5cnZW3YHLtRjLV5Hef3Vs+Ob+3ME0Zl43b/PR6lo0Dj36NeMD31FPtlZ7nf+x0XmCWas58dCHUqXg/eOnCKnw/lop8dgD5+VeZu2MGJQLEOVSs1Ve87mxj2k+C/gKeFVZChnFaFMRhvyRwttcI+8LFMARu50ybn13yaYsnxurbkAh8VOGQjRyBmYoGlqIO3DhJno5PtGzyndMRZ0PkrugrcpqBH0BNQEClGzuITWrEDaX9Or5iHqeFlakwWSkiiLhYeoS8E5JEXYVTST8DowdteOzwqlYGfy/Q/VBY5/qdLSaEFCWITqXzUFzguTALg7dj7lLJJyoJST8ENubcrxTNDorK0ubG0UO2SKlkdRnDJXL+AfigORTDEULqms11ZF+Ga8/85sCdWPBgTd5oi08=
-  bucket: beats-nightlies
-  local-dir: build/binary/upload
-  acl: public_read
-  on:
-    repo: elastic/beats-packer
-    branch: master
-  skip_cleanup: true
-
-notifications:
-  hipchat:
-    rooms:
-      secure: nTzgxmZ2tp2tdAbcpNVGXZ3alUfxqvPQ2MTGu0OMM0U+GcgGpqFk5tlvo3Yb636V2Rhy20absE9/I7tTB6HWHSw2VYtm7IHVWN09tt/2owggqgrdOzU7nlXuuP1m4opiVoeWCtPkcQoT65eCElFYE8djX/h4TgLSdHkcA10/2ayeUBYZxajrGMIAXPXroaqg/KIJtUSvR6lL2p/ttkBDTUP+/ssxF2/4jKDG7fvinP6DT7jfaFsnQ1uNfBMsNc3xDMVfK1MxBraC2300MEX/y2P+3jqhwqjcWDtvskm9ONmq1IF+oav5Vjqo/TWvCYuEDSdVAKzzHcebVgerT7NH0ui+9IW2O5c9q2v+5QS/K4p/0h80RtB+5EoGQX7ETnm2m+7MLoxn8ALESTMoFOPWcLZGEmooGHbJLq4wR7l8NWusnvim7PQGjPIqaphf4Wrrp+H7pbaYuLFQ3sKbp1j+56Y6+NCQSYBp5RbuJLbU6iT5g6eTp4hhsN84cHlEgogXA6PwGWIwIs1ikCqoCoD0SODkWtbF4/6V5j+KPCOSZWsaB0+fTm56Md8Nk471h5vVEjXyx7K3TZJsFHPTkp1v3aaM7Vh42fLZLEUQy1AkRPjZGb8J2BMeoLup2fXENWMDV408IPcOwmuZCtN3xQdoLW3wTOJwajd9Om5TlYxsjGs=
-  email:
-    - tudor@elastic.co


### PR DESCRIPTION
Artifact publishing is now handled by Jenkins and http://nightli.es has be turned off. The [beats-package](http://build-eu-00.elastic.co/view/Beats/job/beats-package/) job publishes artifacts to S3 when it detects changes to master (it is currently configured to publish at most once per hour if there are changes).

Key differences:
- The versions in published artifacts changed from being time-based to now containing the abbreviated SHA commit hash.
- The commit hash is baked into the binary. So running `filebeat --version` from any binary pulled from S3 gives you a traceable version like `filebeat version 1.2.0-nightly1b96e56 (amd64)`.
- We will get faster feedback from beats-tester because beats-tester is triggered automatically when the beats-package job completes.
