### PR TITLE
Save squeeze

### DIFF
--- a/docker/xgo-image-deb6/base/Dockerfile
+++ b/docker/xgo-image-deb6/base/Dockerfile
@@ -7,6 +7,9 @@ FROM debian:6
 
 MAINTAINER Tudor Golubenco <tudor@elastic.co>
 
+# Use sources list from the archive
+ADD sources.list /etc/apt/sources.list
+
 # Configure the Go environment, since it's not going to change
 ENV PATH   /usr/local/go/bin:$PATH
 ENV GOPATH /go
@@ -20,7 +23,7 @@ RUN chmod +x $FETCH
 
 # Make sure apt-get is up to date and dependent packages are installed
 RUN \
-  apt-get update && \
+  apt-get -o Acquire::Check-Valid-Until=false update && \
   apt-get install -y automake autogen build-essential ca-certificates \
     gcc-multilib \
     clang llvm-dev  libtool libxml2-dev uuid-dev libssl-dev pkg-config \

--- a/docker/xgo-image-deb6/base/sources.list
+++ b/docker/xgo-image-deb6/base/sources.list
@@ -1,0 +1,3 @@
+deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze main
+deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze-updates main
+deb http://snapshot.debian.org/archive/debian/20160229T214851Z squeeze-lts main

--- a/docker/xgo-image-deb6/beats-builder/Dockerfile
+++ b/docker/xgo-image-deb6/beats-builder/Dockerfile
@@ -11,7 +11,7 @@ RUN \
 	dpkg -x libpcap0.8-dev_*_amd64.deb /libpcap/amd64 && \
 	rm libpcap0.8-dev*.deb
 RUN \
-	apt-get update && \
+	apt-get -o Acquire::Check-Valid-Until=false update && \
 	apt-get install -y libpcap0.8-dev
 
 # add patch for gopacket


### PR DESCRIPTION
Debian Squeeze is EOL, but we still want to build packages on it.
The main problem is that the repositories were taken down from the
mirrors. Normally we'd use archive for this case, but it seems that
squeeze-updates and squeeze-lts are not (yet?) in it.

So the only solution I found is to pull packages from a snapshot
repository.
