### PR TITLE
APT repo SHA512 signatures

### DIFF
--- a/docker/deb-rpm-s3/deb-s3.expect
+++ b/docker/deb-rpm-s3/deb-s3.expect
@@ -9,6 +9,7 @@ spawn deb-s3 upload \
         --bucket "$env(BUCKET)" \
         --prefix "$env(PREFIX)/apt" \
         --arch $env(arch) \
+        --gpg-options="--digest-algo=SHA512" \
         {*}$argv
 expect {
   "Enter passphrase: " {

--- a/docker/deb-rpm-s3/debsign.expect
+++ b/docker/deb-rpm-s3/debsign.expect
@@ -11,7 +11,7 @@
 #
 #  expect debsign.expect example.deb other.deb
 
-spawn dpkg-sig --sign builder {*}$argv
+spawn dpkg-sig --sign builder --gpg-options="--digest-algo=SHA512" {*}$argv
 expect {
   "Enter passphrase: " {
     send -- "$env(PASS)\r"


### PR DESCRIPTION
Changed signature algorithm used for APT repo to SHA512 because SHA1 causes warning in newer debian releases.

Fixes elastic/beats#2670 for the next Beats 1.X release.

Ref: https://wiki.debian.org/Teams/Apt/Sha1Removal
